### PR TITLE
Implement plugin dependency graph viewer

### DIFF
--- a/NsSpyglass.uplugin
+++ b/NsSpyglass.uplugin
@@ -14,10 +14,10 @@
 	"IsExperimentalVersion": false,
 	"Installed": false,
 	"Modules": [
-		{
-			"Name": "NsSpyglass",
-			"Type": "Runtime",
-			"LoadingPhase": "Default"
-		}
-	]
+                {
+                        "Name": "NsSpyglass",
+                        "Type": "Editor",
+                        "LoadingPhase": "Default"
+                }
+        ]
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # NsSpyglass
-Visualize Unreal Engine Plugin dependencies like never before
+
+Visualize Unreal Engine plugin dependencies inside the editor.
+
+After building the plugin, open **Window > Spyglass > Plugin Dependency Viewer** to explore all loaded plugins and their references.

--- a/Source/NsSpyglass/NsSpyglass.Build.cs
+++ b/Source/NsSpyglass/NsSpyglass.Build.cs
@@ -22,25 +22,25 @@ public class NsSpyglass : ModuleRules
 			);
 			
 		
-		PublicDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"Core",
-				// ... add other public dependencies that you statically link with here ...
-			}
-			);
-			
-		
-		PrivateDependencyModuleNames.AddRange(
-			new string[]
-			{
-				"CoreUObject",
-				"Engine",
-				"Slate",
-				"SlateCore",
-				// ... add private dependencies that you statically link with here ...	
-			}
-			);
+        PublicDependencyModuleNames.AddRange(
+                new string[]
+                {
+                        "Core"
+                }
+                );
+
+
+        PrivateDependencyModuleNames.AddRange(
+                new string[]
+                {
+                        "CoreUObject",
+                        "Engine",
+                        "Slate",
+                        "SlateCore",
+                        "UnrealEd",
+                        "ToolMenus"
+                }
+                );
 		
 		
 		DynamicallyLoadedModuleNames.AddRange(

--- a/Source/NsSpyglass/Private/Widgets/SSpyglassGraphWidget.cpp
+++ b/Source/NsSpyglass/Private/Widgets/SSpyglassGraphWidget.cpp
@@ -1,0 +1,88 @@
+#include "Widgets/SSpyglassGraphWidget.h"
+#include "Interfaces/IPluginManager.h"
+#include "Rendering/DrawElements.h"
+
+void SSpyglassGraphWidget::Construct(const FArguments& InArgs)
+{
+    BuildNodes();
+}
+
+void SSpyglassGraphWidget::BuildNodes() const
+{
+    Nodes.Reset();
+    const TArray<TSharedRef<IPlugin>>& Plugins = IPluginManager::Get().GetEnabledPlugins();
+
+    const float Radius = 300.f;
+    const FVector2D Center(400.f, 400.f);
+    int32 Index = 0;
+    for (const TSharedRef<IPlugin>& Plugin : Plugins)
+    {
+        FPluginNode Node;
+        Node.Name = Plugin->GetName();
+        if (const FPluginDescriptor* Desc = Plugin->GetDescriptor())
+        {
+            for (const FPluginReferenceDescriptor& Ref : Desc->Plugins)
+            {
+                if (Ref.bEnabled)
+                {
+                    Node.Dependencies.Add(Ref.Name);
+                }
+            }
+        }
+        float Angle = (2.f * PI) * Index / Plugins.Num();
+        Node.Position = Center + FVector2D(FMath::Cos(Angle) * Radius, FMath::Sin(Angle) * Radius);
+        Nodes.Add(Node);
+        ++Index;
+    }
+}
+
+int32 SSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry,
+    const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements,
+    int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
+{
+    BuildNodes();
+
+    const FVector2D Offset = AllottedGeometry.GetLocalSize() * 0.5f;
+
+    // Draw edges
+    for (const FPluginNode& Node : Nodes)
+    {
+        for (const FString& DepName : Node.Dependencies)
+        {
+            const FPluginNode* DepNode = Nodes.FindByPredicate([&](const FPluginNode& N){ return N.Name == DepName; });
+            if (DepNode)
+            {
+                TArray<FVector2D> LinePoints;
+                LinePoints.Add(Node.Position - Offset);
+                LinePoints.Add(DepNode->Position - Offset);
+                FSlateDrawElement::MakeLines(OutDrawElements, LayerId, AllottedGeometry.ToPaintGeometry(), LinePoints, ESlateDrawEffect::None, FLinearColor::Gray);
+            }
+        }
+    }
+
+    // Draw nodes
+    for (const FPluginNode& Node : Nodes)
+    {
+        FVector2D DrawPos = Node.Position - Offset - FVector2D(25.f, 25.f);
+        FSlateDrawElement::MakeBox(
+            OutDrawElements,
+            LayerId + 1,
+            AllottedGeometry.ToPaintGeometry(DrawPos, FVector2D(50.f, 50.f)),
+            FCoreStyle::Get().GetBrush("WhiteBrush"),
+            ESlateDrawEffect::None,
+            FLinearColor::Blue
+        );
+        FSlateDrawElement::MakeText(
+            OutDrawElements,
+            LayerId + 2,
+            AllottedGeometry.ToPaintGeometry(DrawPos + FVector2D(5.f, 15.f), FVector2D(40.f,20.f)),
+            Node.Name,
+            FCoreStyle::Get().GetFontStyle("NormalFont"),
+            ESlateDrawEffect::None,
+            FLinearColor::White
+        );
+    }
+
+    return LayerId + 3;
+}
+

--- a/Source/NsSpyglass/Public/NsSpyglass.h
+++ b/Source/NsSpyglass/Public/NsSpyglass.h
@@ -1,5 +1,3 @@
-﻿// Copyright Epic Games, Inc. All Rights Reserved.
-
 #pragma once
 
 #include "Modules/ModuleManager.h"
@@ -7,8 +5,11 @@
 class FNsSpyglassModule : public IModuleInterface
 {
 public:
+    /** IModuleInterface implementation */
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
 
-	/** IModuleInterface implementation */
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
+private:
+    TSharedRef<class SDockTab> OnSpawnPluginTab(const class FSpawnTabArgs& Args);
 };
+

--- a/Source/NsSpyglass/Public/Widgets/SSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SSpyglassGraphWidget.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+struct FPluginNode
+{
+    FString Name;
+    FVector2D Position;
+    TArray<FString> Dependencies;
+};
+
+class SSpyglassGraphWidget : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SSpyglassGraphWidget) {}
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+    virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry,
+        const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements,
+        int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
+
+private:
+    void BuildNodes() const;
+
+    mutable TArray<FPluginNode> Nodes;
+};
+


### PR DESCRIPTION
## Summary
- add simple viewer widget to show plugin dependencies
- register Spyglass editor tab and menu entry
- update build config for editor modules
- mark plugin module as Editor type
- document plugin usage