### PR TITLE
Improve node hover highlighting

### DIFF
--- a/Source/NsSpyglass/Public/Widgets/SSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SSpyglassGraphWidget.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Containers/Set.h"
 
 struct FPluginNode
 {
@@ -37,6 +38,7 @@ private:
     virtual FReply OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
 
     void RecenterView();
+    void UpdateHighlightedNodes(int32 StartIndex) const;
 
     mutable TArray<FPluginNode> Nodes;
     mutable FVector2D ViewOffset = FVector2D::ZeroVector;
@@ -46,5 +48,6 @@ private:
     mutable bool bIsDragging = false;
     mutable int32 DraggedNode = INDEX_NONE;
     mutable int32 HoveredNode = INDEX_NONE;
+    mutable TSet<int32> HighlightedNodes;
 };
 


### PR DESCRIPTION
## Summary
- highlight dependency chain when hovering a node
- store highlighted nodes and update them on mouse move
- draw highlighted edges and nodes in yellow
- track undirected links between plugins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855787fa6e88332ac420dd25dc9c553