### PR TITLE
Add starry parallax background

### DIFF
--- a/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
+++ b/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
@@ -5,6 +5,8 @@
 #include "Interfaces/IPluginManager.h"
 #include "Rendering/DrawElements.h"
 #include "Settings/NsSpyglassSettings.h"
+#include "Brushes/SlateColorBrush.h"
+#include "Styling/CoreStyle.h"
 
 SNsSpyglassGraphWidget::SNsSpyglassGraphWidget()
     : ViewOffset(FVector2D::ZeroVector)
@@ -112,6 +114,26 @@ void SNsSpyglassGraphWidget::BuildNodes(const FVector2D& ViewSize) const
     }
 }
 
+void SNsSpyglassGraphWidget::InitStars(const FVector2D& ViewSize) const
+{
+    if (Stars.Num() == 0 || !ViewSize.Equals(StarsViewSize))
+    {
+        StarsViewSize = ViewSize;
+        Stars.Empty();
+        const int32 NumStars = 150;
+        for (int32 i = 0; i < NumStars; ++i)
+        {
+            FBackgroundStar Star;
+            Star.Position.X = FMath::FRandRange(-ViewSize.X, ViewSize.X);
+            Star.Position.Y = FMath::FRandRange(-ViewSize.Y, ViewSize.Y);
+            Star.Alpha = 0.f;
+            Star.TargetAlpha = FMath::FRandRange(0.2f, 1.f);
+            Star.FadeSpeed = FMath::FRandRange(0.5f, 1.5f);
+            Stars.Add(Star);
+        }
+    }
+}
+
 int32 SNsSpyglassGraphWidget::HitTestNode(const FVector2D& LocalPos, const FVector2D& ViewSize) const
 {
     const FVector2D Center = ViewSize * 0.5f;
@@ -135,7 +157,25 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
         BuildNodes(AllottedGeometry.GetLocalSize());
     }
 
+    InitStars(AllottedGeometry.GetLocalSize());
+
     const FVector2D Center = AllottedGeometry.GetLocalSize() * 0.5f;
+
+    const FSlateBrush* WhiteBrush = FCoreStyle::Get().GetBrush("WhiteBrush");
+    const FVector2D StarOffset = -ViewOffset * 0.1f;
+    for (const FBackgroundStar& Star : Stars)
+    {
+        const FVector2D DrawPos = Center + StarOffset + Star.Position - FVector2D(1.f, 1.f);
+        FSlateDrawElement::MakeBox(
+            OutDrawElements,
+            LayerId,
+            AllottedGeometry.ToPaintGeometry(FVector2D(2.f, 2.f), FSlateLayoutTransform(DrawPos)),
+            WhiteBrush,
+            ESlateDrawEffect::None,
+            FLinearColor(1.f, 1.f, 1.f, Star.Alpha * 0.5f)
+        );
+    }
+    ++LayerId;
 
     TSet<int32> Highlight;
     if (HoveredNode != INDEX_NONE)
@@ -529,5 +569,24 @@ void SNsSpyglassGraphWidget::Tick(const FGeometry& AllottedGeometry, const doubl
 {
     const UNsSpyglassSettings* Settings = UNsSpyglassSettings::GetSettings();
     RunForceAtlas2Step(Nodes, RootIndex, Settings->Repulsion, Settings->CenterForce, InDeltaTime);
+
+    for (FBackgroundStar& Star : Stars)
+    {
+        Star.Alpha = FMath::FInterpTo(Star.Alpha, Star.TargetAlpha, InDeltaTime, Star.FadeSpeed);
+        if (FMath::IsNearlyEqual(Star.Alpha, Star.TargetAlpha, 0.01f))
+        {
+            if (Star.TargetAlpha > 0.f)
+            {
+                Star.TargetAlpha = 0.f;
+            }
+            else
+            {
+                Star.Position.X = FMath::FRandRange(-StarsViewSize.X, StarsViewSize.X);
+                Star.Position.Y = FMath::FRandRange(-StarsViewSize.Y, StarsViewSize.Y);
+                Star.TargetAlpha = FMath::FRandRange(0.2f, 1.f);
+                Star.FadeSpeed = FMath::FRandRange(0.5f, 1.5f);
+            }
+        }
+    }
 }
 

--- a/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
@@ -38,6 +38,22 @@ struct FPluginNode
     TSharedPtr<IPlugin> Plugin;
 };
 
+/** Background star used for the parallax backdrop. */
+struct FBackgroundStar
+{
+    /** Position relative to the center of the screen. */
+    FVector2D Position = FVector2D::ZeroVector;
+
+    /** Current opacity of the star. */
+    float Alpha = 0.f;
+
+    /** Desired opacity to interpolate toward. */
+    float TargetAlpha = 0.f;
+
+    /** Speed of the fade interpolation. */
+    float FadeSpeed = 1.f;
+};
+
 /**
  * Widget that displays all loaded plugins in a force-directed graph
  */
@@ -79,6 +95,9 @@ public:
 
 private:
 
+    /** Create random background stars. */
+    void InitStars(const FVector2D& ViewSize) const;
+
     /** Populate the node array by scanning loaded plugins. */
     void BuildNodes(const FVector2D& ViewSize) const;
 
@@ -118,5 +137,11 @@ private:
 
     /** Delegate for hover updates. */
     FOnNodeHovered OnNodeHovered;
+
+    /** Background stars shown behind the graph. */
+    mutable TArray<FBackgroundStar> Stars;
+
+    /** Cached size for generating star positions. */
+    mutable FVector2D StarsViewSize = FVector2D::ZeroVector;
 };
 


### PR DESCRIPTION
## Summary
- add fading star field structs and members
- render dim stars behind graph with parallax
- update tick to animate background

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685864017e3c83329ef4b156f741b3eb