### PR TITLE
Add starry parallax background

### DIFF
--- a/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
@@ -38,6 +38,22 @@ struct FPluginNode
     TSharedPtr<IPlugin> Plugin;
 };
 
+/** Background star used for the parallax backdrop. */
+struct FBackgroundStar
+{
+    /** Position relative to the center of the screen. */
+    FVector2D Position = FVector2D::ZeroVector;
+
+    /** Current opacity of the star. */
+    float Alpha = 0.f;
+
+    /** Desired opacity to interpolate toward. */
+    float TargetAlpha = 0.f;
+
+    /** Speed of the fade interpolation. */
+    float FadeSpeed = 1.f;
+};
+
 /**
  * Widget that displays all loaded plugins in a force-directed graph
  */
@@ -79,6 +95,9 @@ public:
 
 private:
 
+    /** Create random background stars. */
+    void InitStars(const FVector2D& ViewSize) const;
+
     /** Populate the node array by scanning loaded plugins. */
     void BuildNodes(const FVector2D& ViewSize) const;
 
@@ -118,5 +137,11 @@ private:
 
     /** Delegate for hover updates. */
     FOnNodeHovered OnNodeHovered;
+
+    /** Background stars shown behind the graph. */
+    mutable TArray<FBackgroundStar> Stars;
+
+    /** Cached size for generating star positions. */
+    mutable FVector2D StarsViewSize = FVector2D::ZeroVector;
 };
 


### PR DESCRIPTION
## Summary
- add fading star field structs and members
- render dim stars behind graph with parallax
- update tick to animate background
- adjust parallax direction and clamp delta time

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685864017e3c83329ef4b156f741b3eb