### PR TITLE
Implement zen mode reset and improve name display

### DIFF
--- a/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
@@ -77,6 +77,9 @@ public:
     /** Clear and rebuild all nodes. */
     void RebuildGraph();
 
+    /** Enable or disable Zen mode. */
+    void SetZenMode(bool bInZenMode);
+
 private:
 
     /** Populate the node array by scanning loaded plugins. */
@@ -118,5 +121,8 @@ private:
 
     /** Delegate for hover updates. */
     FOnNodeHovered OnNodeHovered;
+
+    /** Whether Zen mode is active. */
+    bool bZenMode = false;
 };
 


### PR DESCRIPTION
## Summary
- ensure slider values are bound to settings
- add a zen mode toggle that hides the side panels and rebuilds the graph
- expose zen mode API on `SNsSpyglassGraphWidget`
- show long plugin names on two lines with an uppercase header

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68591f7e8d0483328c8ca4d0391fc7b0