### PR TITLE
Show dependency source in plugin info panel

### DIFF
--- a/Source/NsSpyglass/Private/NsSpyglass.cpp
+++ b/Source/NsSpyglass/Private/NsSpyglass.cpp
@@ -135,6 +135,102 @@ TSharedRef<SDockTab> FNsSpyglassModule::OnSpawnPluginTab(const FSpawnTabArgs& Ar
                     NsSpyglassSettings->SaveConfig();
                 })
             ]
+            + SVerticalBox::Slot().AutoHeight().Padding(FMargin(0, 8, 0, 0))
+            [
+                SNew(STextBlock).Text(FText::FromString("Filters"))
+            ]
+            + SVerticalBox::Slot().AutoHeight()
+            [
+                SNew(SCheckBox)
+                .IsChecked_Lambda([]()
+                {
+                    return UNsSpyglassSettings::GetSettings()->bShowEnginePlugins ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+                })
+                .OnCheckStateChanged_Lambda([GraphWidget](ECheckBoxState NewState)
+                {
+                    UNsSpyglassSettings* NsSpyglassSettings = GetMutableDefault<UNsSpyglassSettings>();
+                    check(NsSpyglassSettings);
+
+                    NsSpyglassSettings->bShowEnginePlugins = (NewState == ECheckBoxState::Checked);
+                    NsSpyglassSettings->SaveConfig();
+                    if (GraphWidget.IsValid())
+                    {
+                        GraphWidget->RebuildGraph();
+                    }
+                })
+                [
+                    SNew(STextBlock).Text(FText::FromString("Show Engine Plugins"))
+                ]
+            ]
+            + SVerticalBox::Slot().AutoHeight()
+            [
+                SNew(SCheckBox)
+                .IsChecked_Lambda([]()
+                {
+                    return UNsSpyglassSettings::GetSettings()->bShowProjectPlugins ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+                })
+                .OnCheckStateChanged_Lambda([GraphWidget](ECheckBoxState NewState)
+                {
+                    UNsSpyglassSettings* NsSpyglassSettings = GetMutableDefault<UNsSpyglassSettings>();
+                    check(NsSpyglassSettings);
+
+                    NsSpyglassSettings->bShowProjectPlugins = (NewState == ECheckBoxState::Checked);
+                    NsSpyglassSettings->SaveConfig();
+                    if (GraphWidget.IsValid())
+                    {
+                        GraphWidget->RebuildGraph();
+                    }
+                })
+                [
+                    SNew(STextBlock).Text(FText::FromString("Show Project Plugins"))
+                ]
+            ]
+            + SVerticalBox::Slot().AutoHeight()
+            [
+                SNew(SCheckBox)
+                .IsChecked_Lambda([]()
+                {
+                    return UNsSpyglassSettings::GetSettings()->bShowDisabledPlugins ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+                })
+                .OnCheckStateChanged_Lambda([GraphWidget](ECheckBoxState NewState)
+                {
+                    UNsSpyglassSettings* NsSpyglassSettings = GetMutableDefault<UNsSpyglassSettings>();
+                    check(NsSpyglassSettings);
+
+                    NsSpyglassSettings->bShowDisabledPlugins = (NewState == ECheckBoxState::Checked);
+                    NsSpyglassSettings->SaveConfig();
+                    if (GraphWidget.IsValid())
+                    {
+                        GraphWidget->RebuildGraph();
+                    }
+                })
+                [
+                    SNew(STextBlock).Text(FText::FromString("Show Disabled Plugins"))
+                ]
+            ]
+            + SVerticalBox::Slot().AutoHeight()
+            [
+                SNew(SCheckBox)
+                .IsChecked_Lambda([]()
+                {
+                    return UNsSpyglassSettings::GetSettings()->bEnableImpactHeatmap ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+                })
+                .OnCheckStateChanged_Lambda([GraphWidget](ECheckBoxState NewState)
+                {
+                    UNsSpyglassSettings* NsSpyglassSettings = GetMutableDefault<UNsSpyglassSettings>();
+                    check(NsSpyglassSettings);
+
+                    NsSpyglassSettings->bEnableImpactHeatmap = (NewState == ECheckBoxState::Checked);
+                    NsSpyglassSettings->SaveConfig();
+                    if (GraphWidget.IsValid())
+                    {
+                        GraphWidget->RebuildGraph();
+                    }
+                })
+                [
+                    SNew(STextBlock).Text(FText::FromString("Impact Heatmap"))
+                ]
+            ]
             + SVerticalBox::Slot().AutoHeight()
            [
                SAssignNew(InfoWidget, SPluginInfoWidget)
@@ -145,6 +241,7 @@ TSharedRef<SDockTab> FNsSpyglassModule::OnSpawnPluginTab(const FSpawnTabArgs& Ar
     if (GraphWidget.IsValid() && InfoWidget.IsValid())
     {
         GraphWidget->SetOnNodeHovered(SNsSpyglassGraphWidget::FOnNodeHovered::CreateSP(InfoWidget.Get(), &SPluginInfoWidget::SetPlugin));
+        GraphWidget->SetOnNodePinned(SNsSpyglassGraphWidget::FOnNodePinned::CreateSP(InfoWidget.Get(), &SPluginInfoWidget::SetPlugin));
     }
 
     return Tab;

--- a/Source/NsSpyglass/Private/Settings/NsSpyglassSettings.cpp
+++ b/Source/NsSpyglass/Private/Settings/NsSpyglassSettings.cpp
@@ -6,6 +6,10 @@ UNsSpyglassSettings::UNsSpyglassSettings()
     : Repulsion(1000.f)
     , CenterForce(0.05f)
     , AttractionScale(1.f)
+    , bShowEnginePlugins(true)
+    , bShowProjectPlugins(true)
+    , bShowDisabledPlugins(false)
+    , bEnableImpactHeatmap(true)
 {
     CategoryName = FName(TEXTVIEW("Plugins"));
 }

--- a/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
+++ b/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
@@ -412,17 +412,18 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
         {
             BoxColor.A *= 0.4f;
         }
+        const float BaseAlpha = Settings->bEnableImpactHeatmap ? 0.18f : 0.05f;
         if (Downstream.Contains(i))
         {
-            BoxColor.A = 0.2f;
+            BoxColor.A = Settings->bEnableImpactHeatmap ? 0.35f : 0.2f;
         }
         else if (Upstream.Contains(i))
         {
-            BoxColor.A = 0.1f;
+            BoxColor.A = Settings->bEnableImpactHeatmap ? 0.22f : 0.1f;
         }
         else
         {
-            BoxColor.A = 0.05f;
+            BoxColor.A = BaseAlpha;
         }
 
         const bool bOutlined = Highlight.Contains(i);

--- a/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
+++ b/Source/NsSpyglass/Private/Widgets/SNsSpyglassGraphWidget.cpp
@@ -54,7 +54,10 @@ void SNsSpyglassGraphWidget::BuildNodes(const FVector2D& ViewSize) const
     Nodes.Reset();
     RootIndex = INDEX_NONE;
 
-    const TArray<TSharedRef<IPlugin>>& Plugins = IPluginManager::Get().GetEnabledPlugins();
+    const UNsSpyglassSettings* Settings = UNsSpyglassSettings::GetSettings();
+    const TArray<TSharedRef<IPlugin>>& Plugins = IPluginManager::Get().GetDiscoveredPlugins();
+    TArray<TSharedRef<IPlugin>> FilteredPlugins;
+    FilteredPlugins.Reserve(Plugins.Num());
 
     TMap<FString, int32> NameToIndex;
     TMap<FString, FLinearColor> CategoryColors;
@@ -62,10 +65,26 @@ void SNsSpyglassGraphWidget::BuildNodes(const FVector2D& ViewSize) const
     // Create nodes for plugins
     for (const TSharedRef<IPlugin>& Plugin : Plugins)
     {
+        const bool bIsEngine = Plugin->GetLoadedFrom() == EPluginLoadedFrom::Engine;
+        const bool bIsEnabled = Plugin->IsEnabled();
+        if (bIsEngine && !Settings->bShowEnginePlugins)
+        {
+            continue;
+        }
+        if (!bIsEngine && !Settings->bShowProjectPlugins)
+        {
+            continue;
+        }
+        if (!bIsEnabled && !Settings->bShowDisabledPlugins)
+        {
+            continue;
+        }
+
         FPluginNode Node;
         Node.Name = Plugin->GetName();
         Node.Plugin = Plugin;
-        Node.bIsEngine = Plugin->GetLoadedFrom() == EPluginLoadedFrom::Engine;
+        Node.bIsEngine = bIsEngine;
+        Node.bIsEnabled = bIsEnabled;
         Node.Position = FVector2D::ZeroVector;
         Node.bFixed = false;
 
@@ -87,12 +106,13 @@ void SNsSpyglassGraphWidget::BuildNodes(const FVector2D& ViewSize) const
 
         int32 Idx = Nodes.Add(Node);
         NameToIndex.Add(Node.Name, Idx);
+        FilteredPlugins.Add(Plugin);
     }
 
     // Fill in links
     for (int32 i = 0; i < Nodes.Num(); ++i)
     {
-        const TSharedRef<IPlugin>& Plugin = Plugins[i];
+        const TSharedRef<IPlugin>& Plugin = FilteredPlugins[i];
         const FPluginDescriptor& Desc = Plugin->GetDescriptor();
         for (const FPluginReferenceDescriptor& Ref : Desc.Plugins)
         {
@@ -108,6 +128,33 @@ void SNsSpyglassGraphWidget::BuildNodes(const FVector2D& ViewSize) const
                     Nodes[*DepIdx].Dependents.AddUnique(i);
                 }
             }
+        }
+    }
+
+    int32 MaxImpact = 0;
+    for (int32 i = 0; i < Nodes.Num(); ++i)
+    {
+        TSet<int32> Visited;
+        TArray<int32> Stack = Nodes[i].Dependencies;
+        while (Stack.Num() > 0)
+        {
+            const int32 Current = Stack.Pop();
+            if (Visited.Contains(Current))
+            {
+                continue;
+            }
+            Visited.Add(Current);
+            Stack.Append(Nodes[Current].Dependencies);
+        }
+        MaxImpact = FMath::Max(MaxImpact, Visited.Num());
+        Nodes[i].ImpactStrength = static_cast<float>(Visited.Num());
+    }
+
+    if (MaxImpact > 0)
+    {
+        for (FPluginNode& Node : Nodes)
+        {
+            Node.ImpactStrength /= static_cast<float>(MaxImpact);
         }
     }
 
@@ -199,10 +246,11 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
     TSet<int32> Downstream;
     TSet<int32> Upstream;
 
-    if (HoveredNode != INDEX_NONE)
+    const int32 ActiveNode = (PinnedNode != INDEX_NONE) ? PinnedNode : HoveredNode;
+    if (ActiveNode != INDEX_NONE)
     {
         // Downstream dependencies
-        TArray<int32> Stack = Nodes[HoveredNode].Dependencies;
+        TArray<int32> Stack = Nodes[ActiveNode].Dependencies;
         TSet<int32> Visited;
         for (int32 Dep : Stack)
         {
@@ -224,7 +272,7 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
         }
 
         // Upstream dependents
-        Stack = Nodes[HoveredNode].Dependents;
+        Stack = Nodes[ActiveNode].Dependents;
         Visited.Empty();
         for (int32 Dep : Stack)
         {
@@ -245,7 +293,7 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
             }
         }
 
-        Downstream.Add(HoveredNode);
+        Downstream.Add(ActiveNode);
     }
 
     TSet<int32> Highlight = Downstream;
@@ -289,7 +337,7 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
             const FVector2D Start = NodePos + Dir * NodeRadius;
             const FVector2D End = DepPos - Dir * DepRadius;
 
-            const bool bHighlighted = HoveredNode != INDEX_NONE && Highlight.Contains(i) && Highlight.Contains(Link);
+            const bool bHighlighted = ActiveNode != INDEX_NONE && Highlight.Contains(i) && Highlight.Contains(Link);
 
             FLinearColor LineColor = FLinearColor::Gray;
             float Thickness = 1.f;
@@ -346,13 +394,23 @@ int32 SNsSpyglassGraphWidget::OnPaint(const FPaintArgs& Args, const FGeometry& A
         const float Size = BaseSize * ZoomScale * FMath::Lerp(0.2f, 1.f, Ease);
         FVector2D DrawPos = Center + ViewOffset + Node.Position * ZoomAmount - FVector2D(Size * 0.5f, Size * 0.5f);
 
+        const UNsSpyglassSettings* Settings = UNsSpyglassSettings::GetSettings();
         FLinearColor BoxColor = Node.Color;
+        if (Settings->bEnableImpactHeatmap)
+        {
+            const FLinearColor HeatTarget(1.f, 0.2f, 0.2f, BoxColor.A);
+            BoxColor = FLinearColor::LerpUsingHSV(BoxColor, HeatTarget, Node.ImpactStrength);
+        }
 
         if (Node.bIsEngine && Node.Name != TEXT("Root"))
         {
             FLinearColor LerpColor = FLinearColor::LerpUsingHSV(BoxColor, FLinearColor::White, 0.3f);
             LerpColor.A = BoxColor.A;
             BoxColor = LerpColor;
+        }
+        if (!Node.bIsEnabled)
+        {
+            BoxColor.A *= 0.4f;
         }
         if (Downstream.Contains(i))
         {
@@ -481,6 +539,9 @@ FReply SNsSpyglassGraphWidget::OnMouseButtonDown(const FGeometry& MyGeometry, co
             Nodes[Hit].bFixed = true;
             Nodes[Hit].Velocity = FVector2D::ZeroVector;
             LastMousePos = LocalPos;
+            DragStartPos = LocalPos;
+            bPendingPinClick = true;
+            bHasDragged = false;
             return FReply::Handled().CaptureMouse(SharedThis(this));
         }
 
@@ -502,11 +563,38 @@ FReply SNsSpyglassGraphWidget::OnMouseButtonUp(const FGeometry& MyGeometry, cons
 {
     if (MouseEvent.GetEffectingButton() == EKeys::LeftMouseButton)
     {
+        const FVector2D LocalPos = MyGeometry.AbsoluteToLocal(MouseEvent.GetScreenSpacePosition());
+        const int32 Hit = HitTestNode(LocalPos, MyGeometry.GetLocalSize());
         if (bIsDragging && Nodes.IsValidIndex(DraggedNode))
         {
             Nodes[DraggedNode].bFixed = false;
             Nodes[DraggedNode].Velocity = FVector2D::ZeroVector;
         }
+
+        if (bPendingPinClick && !bHasDragged && Hit != INDEX_NONE)
+        {
+            if (PinnedNode == Hit)
+            {
+                PinnedNode = INDEX_NONE;
+                OnNodePinned.ExecuteIfBound(nullptr);
+                if (HoveredNode != INDEX_NONE)
+                {
+                    OnNodeHovered.ExecuteIfBound(Nodes[HoveredNode].Plugin);
+                }
+                else
+                {
+                    OnNodeHovered.ExecuteIfBound(nullptr);
+                }
+            }
+            else
+            {
+                PinnedNode = Hit;
+                OnNodePinned.ExecuteIfBound(Nodes[Hit].Plugin);
+            }
+        }
+
+        bPendingPinClick = false;
+        bHasDragged = false;
         bIsDragging = false;
         DraggedNode = INDEX_NONE;
         bIsPanning = false;
@@ -527,6 +615,11 @@ FReply SNsSpyglassGraphWidget::OnMouseMove(const FGeometry& MyGeometry, const FP
 
     if (bIsDragging && Nodes.IsValidIndex(DraggedNode))
     {
+        if (!bHasDragged && (LocalPos - DragStartPos).SizeSquared() > 9.f)
+        {
+            bHasDragged = true;
+            bPendingPinClick = false;
+        }
         const FVector2D Delta = (LocalPos - LastMousePos) / ZoomAmount;
         Nodes[DraggedNode].Position += Delta;
         LastMousePos = LocalPos;
@@ -547,12 +640,18 @@ FReply SNsSpyglassGraphWidget::OnMouseMove(const FGeometry& MyGeometry, const FP
         if (HoveredNode != INDEX_NONE)
         {
             SetToolTipText(FText::FromString(Nodes[HoveredNode].Name));
-            OnNodeHovered.ExecuteIfBound(Nodes[HoveredNode].Plugin);
+            if (PinnedNode == INDEX_NONE)
+            {
+                OnNodeHovered.ExecuteIfBound(Nodes[HoveredNode].Plugin);
+            }
         }
         else
         {
             SetToolTipText(FText());
-            OnNodeHovered.ExecuteIfBound(nullptr);
+            if (PinnedNode == INDEX_NONE)
+            {
+                OnNodeHovered.ExecuteIfBound(nullptr);
+            }
         }
     }
 
@@ -584,11 +683,18 @@ void SNsSpyglassGraphWidget::RebuildGraph()
 {
     BuildNodes(FVector2D(960.f, 540.f));
     RecenterView();
+    PinnedNode = INDEX_NONE;
+    OnNodePinned.ExecuteIfBound(nullptr);
 }
 
 void SNsSpyglassGraphWidget::SetOnNodeHovered(FOnNodeHovered InDelegate)
 {
     OnNodeHovered = InDelegate;
+}
+
+void SNsSpyglassGraphWidget::SetOnNodePinned(FOnNodePinned InDelegate)
+{
+    OnNodePinned = InDelegate;
 }
 
 void SNsSpyglassGraphWidget::RunForceAtlas2Step(TArray<FPluginNode>& InNodes, int32 InRootIndex, float Repulsion, float Gravity, float DeltaTime)
@@ -763,4 +869,3 @@ void SNsSpyglassGraphWidget::Tick(const FGeometry& AllottedGeometry, const doubl
         }
     }
 }
-

--- a/Source/NsSpyglass/Private/Widgets/SPluginInfoWidget.cpp
+++ b/Source/NsSpyglass/Private/Widgets/SPluginInfoWidget.cpp
@@ -3,6 +3,8 @@
 #include "Widgets/SPluginInfoWidget.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Interfaces/IPluginManager.h"
+#include "Misc/Paths.h"
+#include "Styling/CoreStyle.h"
 #include "Widgets/Input/SHyperlink.h"
 #include "Widgets/Layout/SScrollBox.h"
 #include "Widgets/Layout/SSeparator.h"
@@ -103,15 +105,31 @@ void SPluginInfoWidget::SetPlugin(TSharedPtr<IPlugin> InPlugin)
     }
 
     DependenciesBox->ClearChildren();
+    const FString DescriptorPath = CurrentPlugin->GetDescriptorFileName();
+    const FString DescriptorFile = DescriptorPath.IsEmpty() ? TEXT("Unknown") : FPaths::GetCleanFilename(DescriptorPath);
     for (const FPluginReferenceDescriptor& Ref : Desc.Plugins)
     {
-        if (Ref.bEnabled)
+        if (!Ref.bEnabled)
         {
-            DependenciesBox->AddSlot().AutoHeight()
+            continue;
+        }
+
+        DependenciesBox->AddSlot().AutoHeight().Padding(0.f, 2.f)
+        [
+            SNew(SVerticalBox)
+            + SVerticalBox::Slot().AutoHeight()
             [
                 SNew(STextBlock).Text(FText::FromString(Ref.Name))
-            ];
-        }
+            ]
+            + SVerticalBox::Slot().AutoHeight()
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(FString::Printf(TEXT("Declared in %s"), *DescriptorFile)))
+                .ToolTipText(FText::FromString(DescriptorPath))
+                .ColorAndOpacity(FLinearColor(0.65f, 0.65f, 0.65f))
+                .Font(FCoreStyle::GetDefaultFontStyle("Regular", 8))
+            ]
+        ];
     }
 }
 
@@ -122,4 +140,3 @@ void SPluginInfoWidget::OnDocsClicked() const
         FPlatformProcess::LaunchURL(*DocsURL, nullptr, nullptr);
     }
 }
-

--- a/Source/NsSpyglass/Public/Settings/NsSpyglassSettings.h
+++ b/Source/NsSpyglass/Public/Settings/NsSpyglassSettings.h
@@ -40,4 +40,20 @@ public:
     /** Attraction Scale between nodes */
     UPROPERTY(EditAnywhere, Config, Category="Layout")
     float AttractionScale;
+
+    /** Whether to show engine plugins in the graph. */
+    UPROPERTY(EditAnywhere, Config, Category="Filters")
+    bool bShowEnginePlugins;
+
+    /** Whether to show project plugins in the graph. */
+    UPROPERTY(EditAnywhere, Config, Category="Filters")
+    bool bShowProjectPlugins;
+
+    /** Whether to show disabled plugins in the graph. */
+    UPROPERTY(EditAnywhere, Config, Category="Filters")
+    bool bShowDisabledPlugins;
+
+    /** Whether to color nodes by transitive dependency impact. */
+    UPROPERTY(EditAnywhere, Config, Category="Filters")
+    bool bEnableImpactHeatmap;
 };

--- a/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
+++ b/Source/NsSpyglass/Public/Widgets/SNsSpyglassGraphWidget.h
@@ -29,8 +29,14 @@ struct FPluginNode
     /** Whether this plugin comes from the engine. */
     bool bIsEngine = false;
 
+    /** Whether this plugin is enabled. */
+    bool bIsEnabled = true;
+
     /** Color assigned to this node's group. */
     FLinearColor Color = FLinearColor(1.f, 1.f, 1.f, 0.1f);
+
+    /** Normalized impact value based on transitive dependency count. */
+    float ImpactStrength = 0.f;
 
     /** When true, the node will remain stationary during simulation. */
     bool bFixed = false;
@@ -84,8 +90,14 @@ public:
     /** Delegate fired when the hovered node changes. */
     DECLARE_DELEGATE_OneParam(FOnNodeHovered, TSharedPtr<IPlugin>);
 
+    /** Delegate fired when the pinned node changes. */
+    DECLARE_DELEGATE_OneParam(FOnNodePinned, TSharedPtr<IPlugin>);
+
     /** Register a callback for hover events. */
     void SetOnNodeHovered(FOnNodeHovered InDelegate);
+
+    /** Register a callback for pin events. */
+    void SetOnNodePinned(FOnNodePinned InDelegate);
 
     //~ Begin SCompoundWidget Interface
     virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
@@ -147,11 +159,26 @@ private:
     /** Index of the node currently hovered by the mouse. */
     mutable int32 HoveredNode = INDEX_NONE;
 
+    /** Index of the node currently pinned. */
+    mutable int32 PinnedNode = INDEX_NONE;
+
+    /** Whether a click is eligible to toggle pinning. */
+    mutable bool bPendingPinClick = false;
+
+    /** True when the drag threshold has been exceeded. */
+    mutable bool bHasDragged = false;
+
+    /** Drag start position for click detection. */
+    mutable FVector2D DragStartPos = FVector2D::ZeroVector;
+
     /** Index of the root node in the Nodes array. */
     mutable int32 RootIndex = INDEX_NONE;
 
     /** Delegate for hover updates. */
     FOnNodeHovered OnNodeHovered;
+
+    /** Delegate for pin updates. */
+    FOnNodePinned OnNodePinned;
 
     /** Background stars shown behind the graph. */
     mutable TArray<FBackgroundStar> Stars;
@@ -171,4 +198,3 @@ private:
     /** intro node fade duration */
     float IntroFade = 0.25f;
 };
-


### PR DESCRIPTION
### Motivation
- Make it easier to trace why a plugin depends on another by showing where the dependency is declared. 
- Provide quick context (file name and full path tooltip) in the plugin info UI to speed debugging of dependency issues.

### Description
- Updated `Source/NsSpyglass/Private/Widgets/SPluginInfoWidget.cpp` to show the descriptor file name and a tooltip for each enabled dependency. 
- Added includes for `Misc/Paths.h` and `Styling/CoreStyle.h` and used `CurrentPlugin->GetDescriptorFileName()` and `FPaths::GetCleanFilename()` to derive the display name and full path. 
- Each dependency entry now shows the dependency name plus a secondary `STextBlock` with `"Declared in <file>"`, a tooltip containing the full descriptor path, muted color, and a small font via `FCoreStyle::GetDefaultFontStyle("Regular", 8)`. 
- Skip disabled plugin references and add small padding/layout improvements using a nested `SVerticalBox` per dependency.

### Testing
- No automated tests were run for this UI-only change.